### PR TITLE
评论添加是审核状态默认设置为1, 评论列表加载时VO中的审核状态默认设置为空; 解决管理端评论列表无法加载的问题

### DIFF
--- a/blog/src/main/java/liuyuyang/net/service/impl/CommentServiceImpl.java
+++ b/blog/src/main/java/liuyuyang/net/service/impl/CommentServiceImpl.java
@@ -14,6 +14,8 @@ import liuyuyang.net.utils.EmailUtils;
 import liuyuyang.net.utils.YuYangUtils;
 import liuyuyang.net.vo.PageVo;
 import liuyuyang.net.vo.comment.CommentFilterVo;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.thymeleaf.TemplateEngine;
@@ -28,6 +30,7 @@ import java.util.Objects;
 
 @Service
 @Transactional
+@Slf4j
 public class CommentServiceImpl extends ServiceImpl<CommentMapper, Comment> implements CommentService {
     @Resource
     private EmailUtils emailUtils;
@@ -112,7 +115,9 @@ public class CommentServiceImpl extends ServiceImpl<CommentMapper, Comment> impl
     @Override
     public List<Comment> list(CommentFilterVo filterVo) {
         QueryWrapper<Comment> queryWrapper = yuYangUtils.queryWrapperFilter(filterVo, "name");
-        queryWrapper.eq("audit_status", filterVo.getStatus());
+        if (filterVo.getStatus() != null) {
+            queryWrapper.eq("audit_status", filterVo.getStatus());
+        }
         if (filterVo.getContent() != null && !filterVo.getContent().isEmpty()) {
             queryWrapper.like("content", filterVo.getContent());
         }

--- a/model/src/main/java/liuyuyang/net/model/Comment.java
+++ b/model/src/main/java/liuyuyang/net/model/Comment.java
@@ -44,5 +44,5 @@ public class Comment extends BaseModel {
     private List<Comment> children = new ArrayList<>();
 
     @ApiModelProperty(value = "评论是否审核通过", example = "1")
-    private Integer auditStatus;
+    private Integer auditStatus = 1;
 }

--- a/model/src/main/java/liuyuyang/net/vo/comment/CommentFilterVo.java
+++ b/model/src/main/java/liuyuyang/net/vo/comment/CommentFilterVo.java
@@ -10,7 +10,7 @@ public class CommentFilterVo extends FilterVo {
     private String pattern;
 
     @ApiModelProperty(value = "0表示获取待审核的评论 | 1表示获取审核通过的评论（默认）")
-    private Integer status = 1;
+    private Integer status;
 
     @ApiModelProperty(value = "根据内容关键词筛选")
     private String content;


### PR DESCRIPTION
在本地测试时发现, 发表评论后在管理端的评论管理中没有评论, 通过阅读评论列表的相关服务发现只加载审核状态为1的评论, 然而添加评论时的审核状态为0, 导致无法显示评论列表, 同时文章页面也没有展示评论, 更改了评论的添加和列表展示的处理逻辑.