### PR TITLE
fix: 生产环境token为空，跳过权限校验

### DIFF
--- a/blog/src/main/java/liuyuyang/net/aspect/PremNameAspect.java
+++ b/blog/src/main/java/liuyuyang/net/aspect/PremNameAspect.java
@@ -65,8 +65,14 @@ public class PremNameAspect {
                 String token = request.getHeader("Authorization");
                 log.debug("Authorization Header: {}", token);
 
+                // 如果 token 为 null，跳过权限校验
+                if (token == null) {
+                    log.info("Token为空，跳过权限校验");
+                    return; // 跳过权限校验
+                }
+
                 // 去掉 Bearer 前缀
-                if (token != null && token.startsWith("Bearer ")) {
+                if (token.startsWith("Bearer ")) {
                     token = token.substring(7);
                 }
 
@@ -116,7 +122,7 @@ public class PremNameAspect {
     // 获取当前方法上的 @PremName 注解
     private Optional<PremName> getMethodAnnotation(JoinPoint joinPoint) {
         return Optional.ofNullable(getCurrentMethod(joinPoint))
-                       .map(method -> method.getAnnotation(PremName.class));
+                .map(method -> method.getAnnotation(PremName.class));
     }
 
     // 获取当前执行的方法对象


### PR DESCRIPTION
在开发环境token是没有问题的，但是在生产环境会在aspect层抛出异常，如果token为空，跳过jwt解析和权限校验

问题复现：
```bash
CustomException{code=401, message=JWT String argument cannot be null or empty.}
        at liuyuyang.net.aspect.PremNameAspect.lambda$before$0(PremNameAspect.java:108)
        at java.base/java.util.Optional.ifPresent(Unknown Source)
        at liuyuyang.net.aspect.PremNameAspect.before(PremNameAspect.java:54)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)
        at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:634)
        at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:617)
        at org.springframework.aop.aspectj.AspectJMethodBeforeAdvice.before(AspectJMethodBeforeAdvice.java:44)
        at org.springframework.aop.framework.adapter.MethodBeforeAdviceInterceptor.invoke(MethodBeforeAdviceInterceptor.java:57)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175)
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
        at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:123)
        at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:388)
        at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
        at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
        at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708)
        at liuyuyang.net.controller.RoleController$$EnhancerBySpringCGLIB$$7ff2038d.getPermissionList(<generated>)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)
        at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205)
        at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:150)
        at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117)
        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:895)
        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808)
        at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
        at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1072)
        at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:965)
        at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)
        at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:529)
        at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:623)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:209)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153)
        at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153)
        at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153)
        at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153)
        at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153)
        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:167)
        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90)
        at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:481)
        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:130)
        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)
        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)
        at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:390)
        at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
        at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:926)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1791)
        at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
        at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191)
        at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
        at java.base/java.lang.Thread.run(Unknown Source)
2025-01-30 20:28:15.301  INFO 1 --- [nio-9003-exec-8] l.n.i.JwtTokenAdminInterceptor           : jwt校验：null
2025-01-30 20:28:15.346  INFO 1 --- [nio-9003-exec-5] l.n.i.JwtTokenAdminInterceptor           : jwt校验：null
2025-01-31 00:52:10.388  INFO 1 --- [nio-9003-exec-1] l.n.i.JwtTokenAdminInterceptor           : jwt校验：null
2025-01-31 00:52:10.388  INFO 1 --- [nio-9003-exec-4] l.n.i.JwtTokenAdminInterceptor           : jwt校验：null
2025-01-31 00:52:10.441  INFO 1 --- [nio-9003-exec-3] l.n.i.JwtTokenAdminInterceptor           : jwt校验：null
2025-01-31 00:52:10.491  INFO 1 --- [nio-9003-exec-2] l.n.i.JwtTokenAdminInterceptor           : jwt校验：null
2025-01-31 00:52:10.591  INFO 1 --- [nio-9003-exec-6] l.n.i.JwtTokenAdminInterceptor           : jwt校验：null
2025-01-31 00:52:11.794  INFO 1 --- [io-9003-exec-10] l.n.i.JwtTokenAdminInterceptor           : jwt校验：null
2025-01-31 00:52:11.801  INFO 1 --- [nio-9003-exec-1] l.n.i.JwtTokenAdminInterceptor           : jwt校验：null
2025-01-31 00:52:11.822  INFO 1 --- [nio-9003-exec-2] l.n.i.JwtTokenAdminInterceptor           : jwt校验：null
```