### PR TITLE
修复README中损坏的Star History图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ ThriveX-Server/
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=LiuYuYang01/ThriveX-Server&type=Date)](https://star-history.com/#LiuYuYang01/ThriveX-Server&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=LiuYuYang01/ThriveX-Server&type=Date)](https://star-history.dera.page/#LiuYuYang01/ThriveX-Server&Date)
 
 
 


### PR DESCRIPTION
当前README中的Star History图表因GitHub stargazer接口限制已经无法正常显示。本PR将其切换到新的数据源star-history.dera.page，该方案使用另一数据源，无需任何API Token即可稳定展示项目Star增长趋势，并且API与前端共用同一域名。